### PR TITLE
Fix sed commands to work on OS X

### DIFF
--- a/bin/rbenv-bundler-ruby-version
+++ b/bin/rbenv-bundler-ruby-version
@@ -25,11 +25,11 @@ version_from_gemfile() {
   # handles simple ruby statements, as well as engine and engine_version,
   # with single or double quotes and in either order
 
-  grep '^\s*ruby' "$GEMFILE_PATH" | sed -e 's/\s*#.*//' -e 's/engine:/:engine =>/' \
+  grep '^\s*ruby' "$GEMFILE_PATH" | sed -e 's/[[:space:]]*#.*//' -e 's/engine:/:engine =>/' \
         -e 's/engine_version:/:engine_version =>/' \
-        -e "s/.*:engine\s*=>\s*['\"]\([^'\"]*\).*:engine_version\s*=>\s*['\"]\([^'\"]*\).*/\1-\2/" \
-        -e "s/.*:engine_version\s*=>\s*['\"]\([^'\"]*\).*:engine\s*=>\s*['\"]\([^'\"]*\).*/\2-\1/" \
-        -e "s/^\s*ruby\s*['\"]\([^'\"]*\).*/\1/" | head -1
+        -e "s/.*:engine[[:space:]]*=>[[:space:]]*['\"]\([^'\"]*\).*:engine_version[[:space:]]*=>[[:space:]]*['\"]\([^'\"]*\).*/\1-\2/" \
+        -e "s/.*:engine_version[[:space:]]*=>[[:space:]]*['\"]\([^'\"]*\).*:engine[[:space:]]*=>[[:space:]]*['\"]\([^'\"]*\).*/\2-\1/" \
+        -e "s/^[[:space:]]*ruby[[:space:]]*['\"]\([^'\"]*\).*/\1/" | head -1
 }
 
 if should_find_in_gemfile; then


### PR DESCRIPTION
\s as an alias for [[:space:]] doesn't work on OS X Mavericks.
putting it into extended mode (-E) isn't compatible with GNU sed, and
doesn't fix the problem.

Test suite fails on OS X before this change, now passes.
