### PR TITLE
Fix rbenv shell and local commands

### DIFF
--- a/bin/rbenv-bundler-ruby-version
+++ b/bin/rbenv-bundler-ruby-version
@@ -18,7 +18,7 @@ find_gemfile_path() {
 }
 
 should_find_in_gemfile() {
-  [ -z "$(rbenv-shell 2>/dev/null)" ] && [ -z "$(rbenv-local 2>/dev/null)" ]
+  [ -z "$(rbenv shell 2>/dev/null)" ] && [ -z "$(rbenv local 2>/dev/null)" ]
 }
 
 version_from_gemfile() {


### PR DESCRIPTION
Updates 'rbenv shell' and 'rbenv local' commands due to the fact that they no longer use a hyphen.

rbenv no longer uses hyphenated commands: https://github.com/sstephenson/rbenv/blob/master/libexec/rbenv-sh-shell#L5