### PR TITLE
per shell RBENV_VERSION overrides Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 rbenv-bundler-ruby-version
 ==========================
 
-Plugin for [rbenv](https://github.com/sstephenson/rbenv) to use a ruby version from [bundler](http://bundler.io/)'s Gemfile. If a custom Ruby version is not already locally per-directory (like in `.ruby-version`), this looks for a Ruby version in the current tree's Gemfile and uses that version.
+Plugin for [rbenv](https://github.com/sstephenson/rbenv) to use a ruby version from
+[bundler](http://bundler.io/)'s Gemfile. If a custom Ruby version 
+is not already defined per-shell or locally per-directory (like in `.ruby-version`), this looks
+for a Ruby version in the current tree's Gemfile and uses that version.
 
 [![Build Status](https://travis-ci.org/aripollak/rbenv-bundler-ruby-version.png?branch=master)](https://travis-ci.org/aripollak/rbenv-bundler-ruby-version)
 
@@ -14,7 +17,10 @@ Installation
       ~/.rbenv/plugins/rbenv-bundler-ruby-version
   ```
   
-1. If you don't already have a symlink in `~/.rbenv/versions` from your latest Ruby patchlevel (2.0.0-p247) to the base version (2.0.0), now would be a good time to do that. You can install [rbenv-aliases](https://github.com/tpope/rbenv-aliases) to make this easier. Once you have rbenv-aliases installed: run:
+1. If you don't already have a symlink in `~/.rbenv/versions` from your latest Ruby patchlevel (2.0.0-p247)
+to the base version (2.0.0), now would be a good time to do that. You can install 
+[rbenv-aliases](https://github.com/tpope/rbenv-aliases)
+to make this easier. Once you have rbenv-aliases installed: run:
 
   ```sh
   rbenv alias --auto
@@ -33,7 +39,9 @@ The logic currently used to find the version is simplistic; rbenv-bundler-ruby-v
 
 The `version*` commands don't report the correct version (they have no hooks)
 
-The parsing is done with regular expressions, i.e. no ruby evaluation is done.  So expressions and conditionals are NOT handled and anything else is not handled.  Prepend `true &&` to the ruby line if you are doing such and want to hide it from this plugin.
+The parsing is done with regular expressions, i.e. no ruby evaluation is done.
+So expressions and conditionals are NOT handled and anything else is not handled.
+Prepend `true && ` to the ruby line if you are doing such and want to hide it from this plugin.
 
 Development
 -----------

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 rbenv-bundler-ruby-version
 ==========================
 
-Plugin for [rbenv](https://github.com/sstephenson/rbenv) to use a ruby version from
-[bundler](http://bundler.io/)'s Gemfile. If a custom Ruby version 
-is not already defined per-shell or locally per-directory (like in `.ruby-version`), this looks
-for a Ruby version in the current tree's Gemfile and uses that version.
+Plugin for [rbenv](https://github.com/sstephenson/rbenv) to use a ruby version
+from [bundler](http://bundler.io/)'s Gemfile. If a custom Ruby version is not
+already defined per-shell or locally per-directory (like in `.ruby-version`),
+this looks for a Ruby version in the current tree's Gemfile and uses that
+version.
 
 [![Build Status](https://travis-ci.org/aripollak/rbenv-bundler-ruby-version.png?branch=master)](https://travis-ci.org/aripollak/rbenv-bundler-ruby-version)
 
@@ -16,21 +17,24 @@ Installation
   git clone https://github.com/aripollak/rbenv-bundler-ruby-version.git \
       ~/.rbenv/plugins/rbenv-bundler-ruby-version
   ```
-  
-1. If you don't already have a symlink in `~/.rbenv/versions` from your latest Ruby patchlevel (2.0.0-p247)
-to the base version (2.0.0), now would be a good time to do that. You can install 
-[rbenv-aliases](https://github.com/tpope/rbenv-aliases)
-to make this easier. Once you have rbenv-aliases installed: run:
+
+1. If you don't already have a symlink in `~/.rbenv/versions` from your latest
+   Ruby patchlevel (2.0.0-p247) to the base version (2.0.0), now would be a
+   good time to do that. You can install
+   [rbenv-aliases](https://github.com/tpope/rbenv-aliases) to make this easier.
+   Once you have rbenv-aliases installed: run:
 
   ```sh
   rbenv alias --auto
   ```
 
-1. That's it! Now `ruby`, `gem`, and your other rbenv shims should automatically find the correct Ruby version.
+1. That's it! Now `ruby`, `gem`, and your other rbenv shims should
+   automatically find the correct Ruby version.
 
 Caveats
 -------
-The logic currently used to find the version is simplistic; rbenv-bundler-ruby-version supports:
+The logic currently used to find the version is simplistic;
+rbenv-bundler-ruby-version supports:
 * simple `ruby '2.0.0'`
 * lines with engines, like:
   * `ruby '2.0.0', engine: 'jruby', engine_version: '1.7.8'`
@@ -40,12 +44,13 @@ The logic currently used to find the version is simplistic; rbenv-bundler-ruby-v
 The `version*` commands don't report the correct version (they have no hooks)
 
 The parsing is done with regular expressions, i.e. no ruby evaluation is done.
-So expressions and conditionals are NOT handled and anything else is not handled.
-Prepend `true && ` to the ruby line if you are doing such and want to hide it from this plugin.
+So expressions and conditionals are NOT handled and anything else is not
+handled.  Prepend `true && ` to the ruby line if you are doing such and want to
+hide it from this plugin.
 
 Development
 -----------
-Pull requests should include test coverage for the bugfix or feature.
-To run tests, install [bats](https://github.com/sstephenson/bats) and
+Pull requests should include test coverage for the bugfix or feature.  To run
+tests, install [bats](https://github.com/sstephenson/bats) and
 [rbenv](https://github.com/sstephenson/rbenv), then run `bats test` in the base
 directory of this plugin.

--- a/bin/rbenv-bundler-ruby-version
+++ b/bin/rbenv-bundler-ruby-version
@@ -18,7 +18,7 @@ find_gemfile_path() {
 }
 
 should_find_in_gemfile() {
-  [ -z "$(rbenv-local 2>/dev/null)" ]
+  [ -z "$RBENV_VERSION" ] && [ -z "$(rbenv-local 2>/dev/null)" ]
 }
 
 version_from_gemfile() {

--- a/test/bundler-ruby-version.bats
+++ b/test/bundler-ruby-version.bats
@@ -10,6 +10,14 @@ load test_helper
   assert_success ''
 }
 
+@test 'Allow overriding version with rbenv shell' {
+  cd_into_project_with_gemfile "'" 1.2.3
+  create_version 4.5.6
+  export RBENV_VERSION=4.5.6
+  run rbenv bundler-ruby-version
+  assert_success ''
+}
+
 @test 'Recognize simple ruby version in single quotes with leading spaces' {
   mkdir -p "$EXAMPLE_APP_DIR"
   cd "$EXAMPLE_APP_DIR"


### PR DESCRIPTION
While it's true that at the time the `which` hooks run, RBENV_VERSION is *always* set (https://github.com/sstephenson/rbenv/blob/9e664b5d27cd7b2bdb94a9ec8ce55c32ebe1ad7a/libexec/rbenv-which#L36); the RBENV_VERSION is not exported. Which means that it is *not* set in any subshells.

And it just so happens, that the `which` hook invokes rbenv-bundler-ruby-version in a subshell: https://github.com/aripollak/rbenv-bundler-ruby-version/blob/9e2320f570e770f4044a8d1f1e11ac3740d66451/etc/rbenv.d/which/bundler-ruby-version.bash#L1

This means that RBENV_VERSION is *not* set in the context of bin/rbenv-bundler-ruby-version, unless explicitly set by the user, which is precisely what we wish to detect.

Example with this PR active:

```
$ head -2 Gemfile
source 'https://rubygems.org'
ruby '2.1.1'
$ rbenv which ruby
/usr/local/var/rbenv/versions/2.1.1/bin/ruby
$ RBENV_VERSION=1.9.3
$ rbenv which ruby
/usr/local/var/rbenv/versions/2.1.1/bin/ruby
$ RBENV_VERSION=1.9.3 rbenv which ruby
/usr/local/var/rbenv/versions/1.9.3/bin/ruby
$ rbenv which ruby
/usr/local/var/rbenv/versions/2.1.1/bin/ruby
$ rbenv shell 2.0.0
$ rbenv which ruby
/usr/local/var/rbenv/versions/2.0.0/bin/ruby
$ rbenv shell --unset
$ rbenv which ruby
/usr/local/var/rbenv/versions/2.1.1/bin/ruby
```

(As [discussed](https://github.com/aripollak/rbenv-bundler-ruby-version/commit/67c64e3cd9de01116f6f4af26dd08f2461c8618d#commitcomment-14356276) at 67c64e3cd9de01116f6f4af26dd08f2461c8618d)